### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.org/ddfreyne/ddplugin.png)](https://travis-ci.org/ddfreyne/ddplugin)
 [![Code Climate](https://codeclimate.com/github/ddfreyne/ddplugin.png)](https://codeclimate.com/github/ddfreyne/ddplugin)
 [![Coverage Status](https://coveralls.io/repos/ddfreyne/ddplugin/badge.png?branch=master)](https://coveralls.io/r/ddfreyne/ddplugin)
+[![Inline docs](http://inch-pages.github.io/github/ddfreyne/ddplugin.png)](http://inch-pages.github.io/github/ddfreyne/ddplugin)
 
 # ddplugin
 


### PR DESCRIPTION
Hi,

like with the other projects, this patch adds your requested docs badge to the README.

I will find out why the overload tag is causing problems, and update the issue you created when that happens.

Thanks for raising the issue!
