### PR TITLE
Prevent #find_all from returning duplicates

### DIFF
--- a/lib/ddplugin/registry.rb
+++ b/lib/ddplugin/registry.rb
@@ -64,7 +64,7 @@ module DDPlugin
     # @return [Enumerable<Class>] A collection of registered classes
     def find_all(root_class)
       @identifiers_to_classes[root_class] ||= {}
-      @identifiers_to_classes[root_class].values
+      @identifiers_to_classes[root_class].values.uniq
     end
   end
 end

--- a/test/test_plugin.rb
+++ b/test/test_plugin.rb
@@ -73,4 +73,17 @@ class DDPlugin::PluginTest < Minitest::Test
 
     assert_equal [klass1, klass2], AllSample.all
   end
+
+  def test_all_with_multiple_identifiers
+    parent_class = Class.new { extend DDPlugin::Plugin }
+
+    klass1 = Class.new(parent_class)
+    klass1.identifier :one_a
+    klass1.identifier :one_b
+
+    klass2 = Class.new(parent_class)
+    klass2.identifier :two
+
+    assert_equal [klass1, klass2], parent_class.all
+  end
 end


### PR DESCRIPTION
Before,

```ruby
class Foo < MyPlugin
  identifier :foo
  identifier :foo2
end

p MyPlugin.all
```

… would return an array that contains `Foo` twice. This PR fixes that.

Fixes nanoc/nanoc#1089.