### PR TITLE
Allow string identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,23 +64,27 @@ class DataSource
 end
 ```
 
-To define a plugin, create a class that inherits from the plugin type and sets the identifier:
+To define a plugin, create a class that inherits from the plugin type and sets the identifier, either as a symbol or a string:
 
 ```ruby
 class ERBFilter < Filter
+  # Specify the identifier as a symbol…
   identifier :erb
 end
 
 class HamlFilter < Filter
-  identifier :haml
+  # … or as a string …
+  identifier 'haml'
 end
 
 class FilesystemDataSource < DataSource
-  identifier :filesystem
+  # … or even provide multiple.
+  identifiers :filesystem, :file_system
 end
 
 class PostgresDataSource < DataSource
-  identifier :postgres
+  # … or mix and match (not sure why you would, though)
+  identifier :postgres, 'postgresql'
 end
 ```
 
@@ -90,7 +94,7 @@ To find a plugin of a given type and with a given identifier, call `.named` on t
 Filter.named(:erb)
 # => ERBFilter
 
-Filter.named(:haml)
+Filter.named('haml')
 # => HamlFilter
 
 DataSource.named(:filesystem)
@@ -98,6 +102,31 @@ DataSource.named(:filesystem)
 
 DataSource.named(:postgres)
 # => PostgresDataSource
+```
+
+In a real-world situation, the plugin types could be described in the environment:
+
+```
+% cat .env
+DATA_SOURCE_TYPE=postgres
+```
+
+```ruby
+DataSource.named(ENV.fetch('DATA_SOURCE_TYPE'))
+# => PostgresDataSource
+```
+
+… or in a configuration file:
+
+```
+% cat config.yml
+data_source: 'filesystem'
+```
+
+```ruby
+config = YAML.load_file('config.yml')
+DataSource.named(config.fetch('data_source'))
+# => FilesystemDataSource
 ```
 
 To get all plugins of a given type, call `.all` on the plugin type:
@@ -110,11 +139,14 @@ DataSource.all
 # => [FilesystemDataSource, PostgresDataSource]
 ```
 
-To get the identifier of a plugin, call `.identifier`:
+To get the identifier of a plugin, call `.identifier`, which returns a symbol:
 
 ```ruby
 Filter.named(:erb).identifier
 # => :erb
+
+Filter.named('haml').identifier
+# => :haml
 
 PostgresDataSource.identifier
 # => :postgres

--- a/lib/ddplugin/plugin.rb
+++ b/lib/ddplugin/plugin.rb
@@ -9,8 +9,8 @@ module DDPlugin
     #
     #   Sets the identifiers for this class.
     #
-    #   @param [Array<Symbol>] identifiers A list of identifiers to assign to
-    #     this class.
+    #   @param [Array<Symbol, String>] identifiers A list of identifiers to
+    #     assign to this class.
     #
     #   @return [void]
     #
@@ -36,7 +36,8 @@ module DDPlugin
     #
     #   Sets the identifier for this class.
     #
-    #   @param [Symbol] identifier The identifier to assign to this class.
+    #   @param [Symbol, String] identifier The identifier to assign to this
+    #     class.
     #
     #   @return [void]
     #
@@ -56,7 +57,7 @@ module DDPlugin
       DDPlugin::Registry.instance.find_all(self)
     end
 
-    # @param [Symbol] identifier The identifier of the class to find
+    # @param [Symbol, String] identifier The identifier of the class to find
     #
     # @return [Class] The class with the given identifier
     def named(identifier)

--- a/lib/ddplugin/registry.rb
+++ b/lib/ddplugin/registry.rb
@@ -27,7 +27,7 @@ module DDPlugin
     #
     # @return [void]
     def register(root_class, klass, *identifiers)
-      identifiers.each do |identifier|
+      identifiers.map(&:to_sym).each do |identifier|
         @classes_to_identifiers[root_class][klass] ||= []
 
         @identifiers_to_classes[root_class][identifier] = klass
@@ -55,6 +55,7 @@ module DDPlugin
     #
     # @return [Class, nil] The class with the given identifier
     def find(root_class, identifier)
+      identifier = identifier.to_sym
       @identifiers_to_classes[root_class] ||= {}
       @identifiers_to_classes[root_class][identifier]
     end

--- a/test/test_plugin.rb
+++ b/test/test_plugin.rb
@@ -30,6 +30,14 @@ class PluginTest < Minitest::Test
     assert_equal :foo, klass.identifier
   end
 
+  def test_identifier_with_string
+    klass = Class.new(IdentifierSample)
+    assert_nil klass.identifier
+
+    klass.identifier 'asdf'
+    assert_equal :asdf, klass.identifier
+  end
+
   def test_identifiers
     klass = Class.new(IdentifierSample)
     assert_empty klass.identifiers
@@ -38,6 +46,17 @@ class PluginTest < Minitest::Test
     assert_equal %i[foo1 foo2], klass.identifiers
 
     klass.identifiers :bar1, :bar2
+    assert_equal %i[foo1 foo2 bar1 bar2], klass.identifiers
+  end
+
+  def test_identifiers_with_string
+    klass = Class.new(IdentifierSample)
+    assert_empty klass.identifiers
+
+    klass.identifiers 'foo1', 'foo2'
+    assert_equal %i[foo1 foo2], klass.identifiers
+
+    klass.identifiers 'bar1', 'bar2'
     assert_equal %i[foo1 foo2 bar1 bar2], klass.identifiers
   end
 
@@ -64,6 +83,14 @@ class PluginTest < Minitest::Test
 
     assert_nil NamedSample.named(:unknown)
     assert_equal klass, NamedSample.named(:named_test)
+  end
+
+  def test_named_with_string
+    klass = Class.new(NamedSample)
+    klass.identifier :named_test
+
+    assert_nil NamedSample.named('unknown')
+    assert_equal klass, NamedSample.named('named_test')
   end
 
   def test_all


### PR DESCRIPTION
This removes the need for `#to_sym` whenever a symbol is passed in.

Before:

```ruby
DataSource.named(ENV.fetch('DATA_SOURCE_TYPE').to_sym)
```

After:

```ruby
DataSource.named(ENV.fetch('DATA_SOURCE_TYPE'))
```